### PR TITLE
Adding guest visibility to avoid to use groups like local.0 and a group ...

### DIFF
--- a/src/main/java/org/esupportail/lecture/dao/XMLUtil.java
+++ b/src/main/java/org/esupportail/lecture/dao/XMLUtil.java
@@ -1,7 +1,5 @@
 package org.esupportail.lecture.dao;
 
-import java.util.List;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dom4j.Node;
@@ -9,74 +7,81 @@ import org.esupportail.lecture.domain.model.DefinitionSets;
 import org.esupportail.lecture.domain.model.RegexOfSet;
 import org.esupportail.lecture.domain.model.RegularOfSet;
 
+import java.util.List;
+
 /**
  * Collection of statis method to parse xml file used by ESUP-Lecture.
  * @author bourges
  */
 public class XMLUtil {
-	/**
-	 * Log instance.
-	 */
-	private static final Log LOG = LogFactory.getLog(XMLUtil.class);
+    /**
+     * Log instance.
+     */
+    private static final Log LOG = LogFactory.getLog(XMLUtil.class);
 
-	/**
-	 * return DefinitionSets from a dom4j node.
-	 * @param node
-	 * @return DefinitionSets the this part of XML
-	 */
-	@SuppressWarnings("unchecked")
-	public static DefinitionSets loadDefAndContentSets(final Node node) {
-		if (LOG.isDebugEnabled()) {
-			String path = "null";
-			if (node != null) {
-				path = node.getPath();
-			}
-			LOG.debug("loadDefAndContentSets(" + path + ")");
-		}
-		DefinitionSets defAndContentSets = new DefinitionSets();
-		if (node != null) {
-			// Definition by group enumeration
-			List<Node> groups = node.selectNodes("group");
-			for (Node group : groups) {
-				String name = group.valueOf("@name");
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("name = " + name);
-				}
-				defAndContentSets.addGroup(name);
-			}
-			// Definition by regular
-			List<Node> regulars = node.selectNodes("regular");
-			for (Node regular : regulars) {
-				String attribute = regular.valueOf("@attribute");
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("attribute = " + attribute);
-				}
-				String value = regular.valueOf("@value");
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("value = " + value);
-				}
-				RegularOfSet regularOfSet = new RegularOfSet();
-				regularOfSet.setAttribute(attribute);
-				regularOfSet.setValue(value);
-				defAndContentSets.addRegular(regularOfSet);
-			}
-			// Definition by regex
-			List<Node> regexs = node.selectNodes("regex");
-			for (Node regex : regexs) {
-				String attribute = regex.valueOf("@attribute");
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("attribute = " + attribute);
-				}
-				String pattern = regex.valueOf("@pattern");
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("pattern = " + pattern);
-				}
-				RegexOfSet regexOfSet = new RegexOfSet();
-				regexOfSet.setAttribute(attribute);
-				regexOfSet.setPattern(pattern);
-				defAndContentSets.addRegex(regexOfSet);
-			}
-		}
-		return defAndContentSets;
-	}
+    /**
+     * return DefinitionSets from a dom4j node.
+     * @param node
+     * @return DefinitionSets the this part of XML
+     */
+    @SuppressWarnings("unchecked")
+    public static DefinitionSets loadDefAndContentSets(final Node node) {
+        if (LOG.isDebugEnabled()) {
+            String path = "null";
+            if (node != null) {
+                path = node.getPath();
+            }
+            LOG.debug("loadDefAndContentSets(" + path + ")");
+        }
+        DefinitionSets defAndContentSets = new DefinitionSets();
+        if (node != null) {
+            // Definition by group enumeration
+            List<Node> groups = node.selectNodes("group");
+            for (Node group : groups) {
+                String name = group.valueOf("@name");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("name = " + name);
+                }
+                defAndContentSets.addGroup(name);
+            }
+            // Definition by regular
+            List<Node> regulars = node.selectNodes("regular");
+            for (Node regular : regulars) {
+                String attribute = regular.valueOf("@attribute");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("attribute = " + attribute);
+                }
+                String value = regular.valueOf("@value");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("value = " + value);
+                }
+                RegularOfSet regularOfSet = new RegularOfSet();
+                regularOfSet.setAttribute(attribute);
+                regularOfSet.setValue(value);
+                defAndContentSets.addRegular(regularOfSet);
+            }
+            // Definition by regex
+            List<Node> regexs = node.selectNodes("regex");
+            for (Node regex : regexs) {
+                String attribute = regex.valueOf("@attribute");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("attribute = " + attribute);
+                }
+                String pattern = regex.valueOf("@pattern");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("pattern = " + pattern);
+                }
+                RegexOfSet regexOfSet = new RegexOfSet();
+                regexOfSet.setAttribute(attribute);
+                regexOfSet.setPattern(pattern);
+                defAndContentSets.addRegex(regexOfSet);
+            }
+            //Defintion by guest
+            List<Node> guest = node.selectNodes("guest");
+            if (!guest.isEmpty()) {
+                defAndContentSets.addGuest();
+            }
+        }
+        return defAndContentSets;
+    }
 }

--- a/src/main/java/org/esupportail/lecture/domain/model/ChannelConfig.java
+++ b/src/main/java/org/esupportail/lecture/domain/model/ChannelConfig.java
@@ -5,13 +5,6 @@
  */
 package org.esupportail.lecture.domain.model;
 
-import java.io.File;
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dom4j.Document;
@@ -21,6 +14,13 @@ import org.esupportail.lecture.dao.FreshXmlFileThread;
 import org.esupportail.lecture.domain.DomainTools;
 import org.esupportail.lecture.exceptions.dao.XMLParseException;
 import org.esupportail.lecture.exceptions.domain.ChannelConfigException;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Channel Config : class used to load and parse XML channel file config.
@@ -345,6 +345,12 @@ public class ChannelConfig  {
 			regexOfSet.setPattern(regex.valueOf("@pattern"));
 			defAndContentSets.addRegex(regexOfSet);
 		}
+
+        fatherPath = "visibility/" + fatherName + "/guest";
+        List<Node> guest = categoryProfile.selectNodes(fatherPath);
+        if (!guest.isEmpty()) {
+            defAndContentSets.addGuest();
+        }
 
 		return defAndContentSets;
 	}

--- a/src/main/java/org/esupportail/lecture/domain/model/DefinitionSets.java
+++ b/src/main/java/org/esupportail/lecture/domain/model/DefinitionSets.java
@@ -15,6 +15,7 @@ import org.apache.commons.logging.LogFactory;
 import org.esupportail.lecture.domain.DomainTools;
 import org.esupportail.lecture.domain.ExternalService;
 import org.esupportail.lecture.exceptions.domain.InternalExternalException;
+import org.esupportail.lecture.exceptions.domain.NoExternalValueException;
 /**
  * DefinitionSets is a the set definition.
  * It can be defined by two ways :
@@ -25,198 +26,235 @@ import org.esupportail.lecture.exceptions.domain.InternalExternalException;
  */
 public class DefinitionSets {
 
-	/*
-	 ************************** PROPERTIES ******************************** */
-	/**
-	 * Log instance.
-	 */
-	protected static final Log LOG = LogFactory.getLog(DefinitionSets.class);
-	/**
-	 * groups : set definition by existent group listing.
-	 */
-	private List<String> groups = new ArrayList<String>();
+    /*
+     ************************** PROPERTIES ******************************** */
+    /**
+     * Log instance.
+     */
+    protected static final Log LOG = LogFactory.getLog(DefinitionSets.class);
+    /**
+     * groups : set definition by existent group listing.
+     */
+    private List<String> groups = new ArrayList<String>();
 
-	/**
-	 * regulars : set definition by regulars.
-	 */
-	private List<RegularOfSet> regulars = new ArrayList<RegularOfSet>();
+    /**
+     * regulars : set definition by regulars.
+     */
+    private List<RegularOfSet> regulars = new ArrayList<RegularOfSet>();
 
-	/**
-	 * regexs : set definition by regexs.
-	 */
-	private List<RegexOfSet> regexs = new ArrayList<RegexOfSet>();
+    /**
+     * regexs : set definition by regexs.
+     */
+    private List<RegexOfSet> regexs = new ArrayList<RegexOfSet>();
 
-	/*
-	 ************************** INIT **********************************/
+    /**
+     * guest : set definition by is current user is guestUser
+     */
+    private boolean guest = false;
 
-	/**
-	 * Constructor.
-	 */
-	public DefinitionSets() {
-		// Nothing to do
-	}
+    /*
+     ************************** INIT **********************************/
 
-	/*
-	 *************************** METHODS ******************************** */
+    /**
+     * Constructor.
+     */
+    public DefinitionSets() {
+        // Nothing to do
+    }
 
-	/**
-	 * Check existence of group names, attributes names used in group enumeration.
-	 * and regulars definition
-	 * Not used for the moment : see later
-	 * Not ready to use without modification
-	 * @deprecated
-	 */
-	@Deprecated
-	protected void checkNamesExistence() {
-	   	if (LOG.isDebugEnabled()) {
-    		LOG.debug("checkNamesExistence()");
-    	}
+    /*
+     *************************** METHODS ******************************** */
+
+    /**
+     * Check existence of group names, attributes names used in group enumeration.
+     * and regulars definition
+     * Not used for the moment : see later
+     * Not ready to use without modification
+     * @deprecated
+     */
+    @Deprecated
+    protected void checkNamesExistence() {
+           if (LOG.isDebugEnabled()) {
+            LOG.debug("checkNamesExistence()");
+        }
 //		Iterator<String> iteratorString;
 //		iteratorString = groups.iterator();
 //		for(String group = null; iteratorString.hasNext();){
 //			group = iteratorString.next();
 //			 TODO (GB later) verification de l'existence du groupe dans le portail
-			// si PB : log.warn();
-			// PAs sure que c'est par le qu'on le fasse
+            // si PB : log.warn();
+            // PAs sure que c'est par le qu'on le fasse
 //		}
 
-		for (RegularOfSet reg : regulars) {
-			reg.checkNamesExistence();
-		}
+        for (RegularOfSet reg : regulars) {
+            reg.checkNamesExistence();
+        }
 
-		// sur le même principe que les regular
-		for (RegexOfSet reg : regexs) {
-			reg.checkNamesExistence();
-		}
-	}
+        // sur le même principe que les regular
+        for (RegexOfSet reg : regexs) {
+            reg.checkNamesExistence();
+        }
+    }
 
-	/**
-	 * Evaluate current user visibility for this DefinitionSets.
-	 * @return true if the user to the set defined by this DefinitionSets
-	 */
-	protected boolean evaluateVisibility() {
-	   	if (LOG.isDebugEnabled()) {
-    		LOG.debug("evaluateVisibility()");
-    	}
+    /**
+     * Evaluate current user visibility for this DefinitionSets.
+     * @return true if the user to the set defined by this DefinitionSets
+     */
+    protected boolean evaluateVisibility() {
+           if (LOG.isDebugEnabled()) {
+            LOG.debug("evaluateVisibility()");
+        }
 
-		/* group evaluation */
-		Iterator<String> iteratorGroups = groups.iterator();
-		while (iteratorGroups.hasNext()) {
-			String group = iteratorGroups.next();
-			if (LOG.isTraceEnabled()) {
-				LOG.trace("DefinitionSets, evaluation on group : " + group);
-			}
-			try {
-				ExternalService ex = DomainTools.getExternalService();
-				if (ex.isUserInGroup(group)) {
-					return true;
-				}
-			} catch (InternalExternalException e) {
-				LOG.error("Group user evaluation impossible (external service unavailable) : "
-						+ e.getMessage());
-			}
+        /* group evaluation */
+        Iterator<String> iteratorGroups = groups.iterator();
+        while (iteratorGroups.hasNext()) {
+            String group = iteratorGroups.next();
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("DefinitionSets, evaluation on group : " + group);
+            }
+            try {
+                ExternalService ex = DomainTools.getExternalService();
+                if (ex.isUserInGroup(group)) {
+                    return true;
+                }
+            } catch (InternalExternalException e) {
+                LOG.error("Group user evaluation impossible (external service unavailable) : "
+                        + e.getMessage());
+            }
 
-		}
+        }
 
-		/* regulars evaluation */
-		Iterator<RegularOfSet> iteratorReg = regulars.iterator();
-		while (iteratorReg.hasNext()) {
-			RegularOfSet reg = iteratorReg.next();
-			if (LOG.isTraceEnabled()) {
-				LOG.trace("DefinionSets, evaluation regular : attr("
-					+ reg.getAttribute() + ") val(" + reg.getValue() + ")");
-			}
-			if (reg.evaluate()) {
-				return true;
-			}
-		}
+        /* regulars evaluation */
+        Iterator<RegularOfSet> iteratorReg = regulars.iterator();
+        while (iteratorReg.hasNext()) {
+            RegularOfSet reg = iteratorReg.next();
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("DefinionSets, evaluation regular : attr("
+                    + reg.getAttribute() + ") val(" + reg.getValue() + ")");
+            }
+            if (reg.evaluate()) {
+                return true;
+            }
+        }
 
-		/* regexs evaluation */
-		Iterator<RegexOfSet> iteratorRegex = regexs.iterator();
-		while (iteratorRegex.hasNext()) {
-			RegexOfSet reg = iteratorRegex.next();
-			if (LOG.isTraceEnabled()) {
-				LOG.trace("DefinionSets, evaluation regex : attr("+ reg.toString() + ")");
-			}
-			if (reg.evaluate()) {
-				return true;
-			}
-		}
+        /* regexs evaluation */
+        Iterator<RegexOfSet> iteratorRegex = regexs.iterator();
+        while (iteratorRegex.hasNext()) {
+            RegexOfSet reg = iteratorRegex.next();
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("DefinionSets, evaluation regex : attr("+ reg.toString() + ")");
+            }
+            if (reg.evaluate()) {
+                return true;
+            }
+        }
 
-		return false;
-	}
+        /* guest evaluation */
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("DefinitionSets, evaluation on guest : " + guest);
+        }
+        if (guest) {
+            try {
+                ExternalService ex = DomainTools.getExternalService();
+                if (ex.getConnectedUserId().equalsIgnoreCase(DomainTools.getGuestUser())) {
+                    return true;
+                }
+            } catch (NoExternalValueException e) {
+                LOG.warn("Guest user evaluation impossible (NoExternalValueException) : " + e.getMessage());
+                return false;
+            } catch (InternalExternalException e) {
+                LOG.error("Guest user evaluation impossible (external service unavailable) : "
+                        + e.getMessage());
+                return false;
+            }
+        }
 
-	/**
-	 * Add a group in groups enumeration of this DefintionSets.
-	 * @param group group to add
-	 * @see DefinitionSets#groups
-	 */
-	public synchronized void addGroup(final String group) {
-	   	if (LOG.isDebugEnabled()) {
-    		LOG.debug("addGroup(" + group + ")");
-    	}
-		this.groups.add(group);
-	}
+        return false;
+    }
 
-	/**
-	 * Add a regulars in list of regulars of this DefintionSets.
-	 * @param regular
-	 * @see DefinitionSets#regulars
-	 */
-	public synchronized void addRegular(final RegularOfSet regular) {
-	   	if (LOG.isDebugEnabled()) {
-	   		LOG.debug("addRegular(" + regular.toString() + ")");
-    	}
-		this.regulars.add(regular);
-	}
+    /**
+     * Add a group in groups enumeration of this DefintionSets.
+     * @param group group to add
+     * @see DefinitionSets#groups
+     */
+    public synchronized void addGroup(final String group) {
+           if (LOG.isDebugEnabled()) {
+            LOG.debug("addGroup(" + group + ")");
+        }
+        this.groups.add(group);
+    }
 
-	/**
-	 * Add a regexs in list of regexs of this DefintionSets.
-	 * @param regex
-	 * @see DefinitionSets#regexs
-	 */
-	public synchronized void addRegex(final RegexOfSet regex) {
-	   	if (LOG.isDebugEnabled()) {
-    		LOG.debug("addRegex(" + regex.toString() + ")");
-    	}
-		this.regexs.add(regex);
-	}
+    /**
+     * Add a regulars in list of regulars of this DefintionSets.
+     * @param regular
+     * @see DefinitionSets#regulars
+     */
+    public synchronized void addRegular(final RegularOfSet regular) {
+           if (LOG.isDebugEnabled()) {
+               LOG.debug("addRegular(" + regular.toString() + ")");
+        }
+        this.regulars.add(regular);
+    }
 
-	/**
-	 * Add a definitionSets to the current definitionSets.
-	 * @param definitionSets - the definitionSets to add
-	 */
-	public void addDefinitionSets(final DefinitionSets definitionSets) {
-		this.groups.addAll(definitionSets.groups);
-		this.regulars.addAll(definitionSets.regulars);
-		this.regexs.addAll(definitionSets.regexs);
-	}
+    /**
+     * Add a regexs in list of regexs of this DefintionSets.
+     * @param regex
+     * @see DefinitionSets#regexs
+     */
+    public synchronized void addRegex(final RegexOfSet regex) {
+           if (LOG.isDebugEnabled()) {
+            LOG.debug("addRegex(" + regex.toString() + ")");
+        }
+        this.regexs.add(regex);
+    }
 
-	/**
-	 * @return if DefinitionSets is Empty or not
-	 */
-	public boolean isEmpty() {
-		boolean ret = false;
-		if (groups.isEmpty() && regulars.isEmpty() && regexs.isEmpty()) {
-			ret = true;
-		}
-		return ret;
-	}
+    /**
+     * Add a Guest test of this DefintionSets
+     */
+    public synchronized void addGuest() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("addGuest");
+        }
+        this.guest = true;
+    }
 
-	/**
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
+    /**
+     * Add a definitionSets to the current definitionSets.
+     * @param definitionSets - the definitionSets to add
+     */
+    public void addDefinitionSets(final DefinitionSets definitionSets) {
+        this.groups.addAll(definitionSets.groups);
+        this.regulars.addAll(definitionSets.regulars);
+        this.regexs.addAll(definitionSets.regexs);
+        this.guest = definitionSets.guest;
+    }
 
-		String string = "";
-		string += "		groups : " + groups.toString() + "\n";
-		string += "		regulars : " + regulars.toString() + "\n";
-		string += "		regexs : " + regexs.toString() + "\n";
+    /**
+     * @return if DefinitionSets is Empty or not
+     */
+    public boolean isEmpty() {
+        boolean ret = false;
+        if (groups.isEmpty() && regulars.isEmpty() && regexs.isEmpty() && !guest) {
+            ret = true;
+        }
+        return ret;
+    }
 
-		return string;
-	}
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
 
-	/* ************************** ACCESSORS ******************************** */
+        String string = "";
+        string += "		groups : " + groups.toString() + "\n";
+        string += "		regulars : " + regulars.toString() + "\n";
+        string += "		regexs : " + regexs.toString() + "\n";
+        string += "		guest : " + guest + "\n";
+
+        return string;
+    }
+
+    /* ************************** ACCESSORS ******************************** */
 
 }

--- a/src/main/resources/properties/esup-lecture.dtd
+++ b/src/main/resources/properties/esup-lecture.dtd
@@ -38,9 +38,9 @@
 
 <!ELEMENT visibility (allowed,autoSubscribed,obliged)>
 
-<!ELEMENT allowed (regular*, regex*, group*)>
-<!ELEMENT autoSubscribed (regular*, regex*, group*)>
-<!ELEMENT obliged (regular*, regex*, group*)>
+<!ELEMENT allowed (regular*, regex*, group*, guest?)>
+<!ELEMENT autoSubscribed (regular*, regex*, group*, guest?)>
+<!ELEMENT obliged (regular*, regex*, group*, guest?)>
 
 <!ELEMENT regular EMPTY>
 <!ATTLIST regular

--- a/src/main/resources/properties/examples/xml/category.dtd
+++ b/src/main/resources/properties/examples/xml/category.dtd
@@ -9,7 +9,7 @@
 
 <!ELEMENT sourceProfile (visibility?)>
 <!ATTLIST sourceProfile
-	id ID #REQUIRED
+    id ID #REQUIRED
     name CDATA #REQUIRED
     url CDATA #REQUIRED
     xslt CDATA #IMPLIED
@@ -21,9 +21,9 @@
 
 <!ELEMENT visibility (allowed,autoSubscribed,obliged)>
 
-<!ELEMENT allowed (regular*, regex*, group*)>
-<!ELEMENT autoSubscribed (regular*, regex*, group*)>
-<!ELEMENT obliged (regular*, regex*, group*)>
+<!ELEMENT allowed (regular*, regex*, group*, guest?)>
+<!ELEMENT autoSubscribed (regular*, regex*, group*, guest?)>
+<!ELEMENT obliged (regular*, regex*, group*, guest?)>
 
 <!ELEMENT regular EMPTY>
 <!ATTLIST regular
@@ -37,3 +37,5 @@
 
 <!ELEMENT group EMPTY>
 <!ATTLIST group name CDATA #REQUIRED>
+
+<!ELEMENT guest EMPTY>


### PR DESCRIPTION
...local.X depending on insertion order in database

It's an improvment that we use to load the portlet in guestMode. To use it simply define a context for the guest user and add only in the visibility type (allowed/obliged...) the node <guest/>

We save several seconds in welcome page loading of our portal (usefull when you have large groups).

More it avoids to define the visibility on a local group which the id is database init order dependent.
