### PR TITLE
Correction Vulnerabilité commons-collections-3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>3.2.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.esupportail</groupId>
                 <artifactId>esup-commons2-exceptionHandling</artifactId>
                 <version>${esupcommons.version}</version>
@@ -379,6 +384,10 @@
         <dependency>
             <groupId>org.jasig.resourceserver</groupId>
             <artifactId>resource-server-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
En attendant la màj d'esup-commons (s'il y a) on force la version corrigeant la vulnérabilité
cf https://commons.apache.org/proper/commons-collections/security-reports.html